### PR TITLE
Fix data generation docs on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,11 @@ Then, generate an ImageNet dataset; make the dataset used for the results above 
 export IMAGENET_DIR=/path/to/pytorch/format/imagenet/directory/
 export WRITE_DIR=/your/path/here/
 
-# Starting in the root of the Git repo:
-cd examples;
-
 # Serialize images with:
 # - 500px side length maximum
 # - 50% JPEG encoded, 90% raw pixel values
 # - quality=90 JPEGs
-./write_dataset.sh 500 0.50 90
+./write_imagenet.sh 500 0.50 90
 ```
 Then, choose a configuration from the [configuration table](#configurations). With the config file path in hand, train as follows:
 ```bash


### PR DESCRIPTION
Just a simple fix regarding the command on README to generate the datasets. Alsos I've taken out the comment and command to go to the examples folder since it was quite confusing for me since those commands should be run on this repo root folder. But let me know if this was not the right call and how it could be made more clear.

--
Thanks for this amazing work, I'm excited to try it :)